### PR TITLE
feat: implements internal claim function

### DIFF
--- a/solidity/contracts/MultipleExpirableAirdrops.sol
+++ b/solidity/contracts/MultipleExpirableAirdrops.sol
@@ -72,7 +72,7 @@ contract MultipleExpirableAirdrops is IMultipleExpirableAirdrops, Governable {
     bool _isValidLeaf = MerkleProof.verify(_merkleProof, _trancheMerkleRoot, _leaf);
     if (!_isValidLeaf) revert InvalidProof();
 
-    bytes32 _claimId = keccak256(abi.encodePacked(_trancheMerkleRoot, msg.sender));
+    bytes32 _claimId = keccak256(abi.encodePacked(_trancheMerkleRoot, _claimee));
     if (claimedTranches[_claimId]) revert AlreadyClaimed();
     claimedTranches[_claimId] = true;
 

--- a/solidity/contracts/test/MultipleExpirableAirdrops.sol
+++ b/solidity/contracts/test/MultipleExpirableAirdrops.sol
@@ -27,6 +27,16 @@ contract MultipleExpirableAirdropsMock is MultipleExpirableAirdrops {
     }
   }
 
+  function claim(
+    bytes32 _trancheMerkleRoot,
+    address _claimee,
+    uint112 _amount,
+    address _recipient,
+    bytes32[] calldata _merkleProof
+  ) external {
+    super._claim(_trancheMerkleRoot, _claimee, _amount, _recipient, _merkleProof);
+  }
+
   function _claim(
     bytes32 _trancheMerkleRoot,
     address _claimee,


### PR DESCRIPTION
We finally implement what this is all about: The `claim` function. I'll add `e2e` to prove that malicious claims with wrong proofs, repeated, or with wrong information can't be done. Also, still missing deployment script. 